### PR TITLE
fix nil pointer when ctx.Done

### DIFF
--- a/bench/scenario_normal.go
+++ b/bench/scenario_normal.go
@@ -32,6 +32,9 @@ func (s *Scenario) NormalScenario(ctx context.Context, step *isucandar.Benchmark
 	defer report()
 
 	user, release := s.ChoiceUser(ctx, s.NormalUsers)
+	if user == nil {
+		return nil
+	}
 	defer release()
 	ag, _ := user.GetAgent(s.Option)
 	{


### PR DESCRIPTION
s.ChoiceUser returns nil when ctx.Done. So, user.GetAgent returns nil pointer dereference.